### PR TITLE
Use string instead of symbol to look up parameters

### DIFF
--- a/lib/analytics_instrumentation/analytics_mapping.rb
+++ b/lib/analytics_instrumentation/analytics_mapping.rb
@@ -22,7 +22,7 @@ class AnalyticsMapping
 
     replaceAllTokens(analysis, params, view_assigns)
 
-    analysis[:parameters] ||= {}
+    analysis["parameters"] ||= {}
 
     HashWithIndifferentAccess.new(analysis)
   end


### PR DESCRIPTION
Looking up the parameters with symbol `:parameters` is returning nil. The correct key appears to be `"parameters"`.
